### PR TITLE
Sanity check on signup protection

### DIFF
--- a/cloud-functions/firestore.rules
+++ b/cloud-functions/firestore.rules
@@ -33,6 +33,8 @@ service cloud.firestore {
     function isNotEscalatingPrivileges() {
       return ( resource.data.isAdmin == request.resource.data.isAdmin )
     }
+
+    // Checks that the caller is not trying to change the organizationID in the request
     function isModifyingOrg() {
       return ( resource.data.organizationID != request.resource.data.organizationID )
     }

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -53,7 +53,7 @@ afterEach(async () => {
   }
 });
 
-test('clientAuth.createUser winds up with a deleted user even if they try to quickly create their own record in /users table', async () => {
+test('An attacker cannot create an account and then quickly create their own record in /users table before onCreate has time to run and delete them', async () => {
   // Attacker creates an account with the client auth
   await clientAuth.createUserWithEmailAndPassword('shouldBe@deleted.com', 'shouldBe@deleted.com');
   // Immediately signs in

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { adminDb, clientAuth, adminAuth, createUser, delay, DELAY, soylentGreenID } from './config';
+import { adminDb, clientAuth, adminAuth, createUser, delay, DELAY, soylentGreenID, clientDb } from './config';
 
 jest.setTimeout(120000);
 
@@ -23,25 +23,22 @@ const testUserEmail =
  */
 async function copyUser(oldEmail: string, newEmail: string) {
   // Copy user data
-  const userData = (await adminDb.collection('users').doc(oldEmail).get()).data()!
-  await adminDb.collection('users').doc(newEmail).set(userData)
+  const userData = (await adminDb.collection('users').doc(oldEmail).get()).data()!;
+  await adminDb.collection('users').doc(newEmail).set(userData);
 
   // Create auth record
   const userRecord = await adminAuth.createUser({
     email: newEmail,
     password: newEmail,
-  })
-  testUid = userRecord.uid
+  });
+  testUid = userRecord.uid;
 }
 
 afterEach(async () => {
   try {
     await adminAuth.deleteUser(testUid);
     try {
-      await adminDb
-        .collection('users')
-        .doc(testUserEmail)
-        .delete();
+      await adminDb.collection('users').doc(testUserEmail).delete();
       await clientAuth.signOut().catch((err) => {
         console.error(err);
       });
@@ -53,6 +50,28 @@ afterEach(async () => {
     await clientAuth.signOut().catch((err1) => {
       console.error(err1);
     });
+  }
+});
+
+test('clientAuth.createUser winds up with a deleted user even if they try to quickly create their own record in /users table', async () => {
+  // Attacker creates an account with the client auth
+  await clientAuth.createUserWithEmailAndPassword('shouldBe@deleted.com', 'shouldBe@deleted.com');
+  // Immediately signs in
+  await clientAuth.signInWithEmailAndPassword('shouldBe@deleted.com', 'shouldBe@deleted.com');
+  // Immediately attempts to create their own record in the /users table before onCreate has time to run and delete them
+  try {
+    await clientDb.collection('users').doc('shouldBe@deleted.com').set({
+      isAdmin: true,
+      organizationID: soylentGreenID,
+      disabled: false,
+      firstName: 'ShouldBe',
+      lastName: 'Deleted',
+      isFirstTimeUser: false,
+    });
+    fail('We are vulnerable!');
+  } catch (err) {
+    expect(err.code).toEqual('permission-denied');
+    expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
   }
 });
 
@@ -68,8 +87,7 @@ test('createUser cannot be called without being authenticated', async () => {
 
 test('createUser cannot be called by non-admin', async () => {
   try {
-    await clientAuth
-      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com');
+    await clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com');
     try {
       await createUser({});
       fail("This shouldn't happen!");
@@ -84,8 +102,7 @@ test('createUser cannot be called by non-admin', async () => {
 });
 
 test('Email address can only be used once', async () => {
-  await clientAuth
-    .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
+  await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
   try {
     await createUser({
       email: 'user@soylentgreen.com',
@@ -106,13 +123,15 @@ test('Email address can only be used once', async () => {
 test('createUser works for admins', async () => {
   await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
 
-  const userRecord = (await createUser({
-    email: testUserEmail,
-    password: testUserEmail,
-    firstName: 'test',
-    lastName: 'user',
-    isAdmin: false,
-  })).data;
+  const userRecord = (
+    await createUser({
+      email: testUserEmail,
+      password: testUserEmail,
+      firstName: 'test',
+      lastName: 'user',
+      isAdmin: false,
+    })
+  ).data;
   testUid = userRecord.uid;
 
   // Check that the endpoint responded with the proper user
@@ -120,13 +139,10 @@ test('createUser works for admins', async () => {
 
   // Check that corresponding document in userImages was created
   console.log(`testUserEmail = ${testUserEmail}`);
-  const docSnapshot = await adminDb
-    .collection('userImages')
-    .doc(testUserEmail)
-    .get();
+  const docSnapshot = await adminDb.collection('userImages').doc(testUserEmail).get();
   expect(docSnapshot.exists).toEqual(true);
 
-  // delay for 10 sec to allow functions.auth.user().onCreate to trigger and propagate
+  // delay for DELAY sec to allow functions.auth.user().onCreate to trigger and propagate
   await delay(DELAY);
 
   await clientAuth.signInWithEmailAndPassword(testUserEmail, testUserEmail);
@@ -143,21 +159,23 @@ test('createUser works for admins', async () => {
   // Check that custom claims are being added properly
   expect(idTokenResult.claims.isAdmin).toEqual(false);
   expect(idTokenResult.claims.organizationID).toEqual(soylentGreenID);
-})
+});
 
 test('createUser works for emails with uppercase letters', async () => {
   await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
-  
-  const userRecord = (await createUser({
-    email: 'UPPERCASE@email.com',
-    password: 'password',
-    firstName: 'test',
-    lastName: 'user',
-    isAdmin: false,
-  })).data;
+
+  const userRecord = (
+    await createUser({
+      email: 'UPPERCASE@email.com',
+      password: 'password',
+      firstName: 'test',
+      lastName: 'user',
+      isAdmin: false,
+    })
+  ).data;
 
   testUid = userRecord.uid;
-  
+
   // Check that the endpoint responded with the proper user
   expect(userRecord.email).toEqual('uppercase@email.com');
 
@@ -171,14 +189,11 @@ test('createUser works for emails with uppercase letters', async () => {
     throw new Error('clientAuth.currentUser returned null');
   }
   expect(currentUser.email).toEqual('uppercase@email.com');
-  
+
   await delay(DELAY);
-  const userDoc = await adminDb
-    .collection('users')
-    .doc('uppercase@email.com')
-    .get();
-  
-    expect(userDoc.exists).toBe(true);
+  const userDoc = await adminDb.collection('users').doc('uppercase@email.com').get();
+
+  expect(userDoc.exists).toBe(true);
   // delete uppercase user to keep test idempotent
   await adminDb.collection('users').doc('uppercase@email.com').delete();
 });
@@ -190,7 +205,7 @@ test('createUser fails if invalid request body', async () => {
       email: testUserEmail,
       password: testUserEmail,
       // Missing required fields
-    })
+    });
     fail('createUser returned a 200 despite improperly formatted request');
   } catch (err) {
     expect(err.code).toEqual('invalid-argument');
@@ -199,38 +214,31 @@ test('createUser fails if invalid request body', async () => {
 });
 
 test('Attempting to sign up a user through clientAuth.createUserWithEmailAndPassword and not through createUser endpoint results in the user being deleted', async () => {
-  const userCredential = await clientAuth
-    .createUserWithEmailAndPassword(testUserEmail, testUserEmail);
+  const userCredential = await clientAuth.createUserWithEmailAndPassword(testUserEmail, testUserEmail);
   expect(userCredential.user?.email).toEqual(testUserEmail);
   if (userCredential.user) {
     testUid = userCredential.user.uid;
   }
   await delay(DELAY * 2);
-  const user = await adminDb
-    .doc('users/' + testUserEmail)
-    .get();
+  const user = await adminDb.doc('users/' + testUserEmail).get();
   expect(user.exists).toEqual(false);
 });
 
 test("Manually added, improperly formatted user in users table can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      // This is missing fields
-    })
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    // This is missing fields
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    })
-  
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
+
   // delay to allow onCreate to trigger and realize users table document is faulty
-  await delay(DELAY * 2)
+  await delay(DELAY * 2);
 
   // check that user has been deleted from Firebase Auth
   try {
@@ -238,33 +246,26 @@ test("Manually added, improperly formatted user in users table can't be signed u
     fail("Improperly formatted user should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test("Manually added user in users table with non-existent organizationID can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      organizationID: "This id doesn't exist",
-      disabled: false,
-      firstName: 'test',
-      lastName: 'user',
-    });
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    organizationID: "This id doesn't exist",
+    disabled: false,
+    firstName: 'test',
+    lastName: 'user',
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    });
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
 
   // delay to allow onCreate to trigger and realize users table document is faulty
   await delay(DELAY * 2);
@@ -272,82 +273,62 @@ test("Manually added user in users table with non-existent organizationID can't 
   // check that user has been deleted from Firebase Auth
   try {
     await adminAuth.getUserByEmail(testUserEmail);
-    fail(
-      "User with non-existent organizationID should have been deleted from Auth but wasn't"
-    );
+    fail("User with non-existent organizationID should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test("Manually added user in users table with empty string organizationID can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      organizationID: '',
-      disabled: false,
-      firstName: 'test',
-      lastName: 'user',
-    });
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    organizationID: '',
+    disabled: false,
+    firstName: 'test',
+    lastName: 'user',
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    });
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
 
   // delay to allow onCreate to trigger and realize users table document is faulty
-  await delay(DELAY * 2)
+  await delay(DELAY * 2);
 
   // check that user has been deleted from Firebase Auth
   try {
     await adminAuth.getUserByEmail(testUserEmail);
-    fail(
-      "User with empty string organizationID should have been deleted from Auth but wasn't"
-    );
+    fail("User with empty string organizationID should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test('User can be toggled between enabled and disabled', async () => {
   // Create a new user to avoid race conditions
-  await copyUser('disabled@soylentgreen.com', testUserEmail)
+  await copyUser('disabled@soylentgreen.com', testUserEmail);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      disabled: false,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    disabled: false,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
 
   const userRecordDisabled = await adminAuth.getUserByEmail(testUserEmail);
   expect(userRecordDisabled.disabled).toBe(false);
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      disabled: true,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    disabled: true,
+  });
 
-    // Delay to allow userOnUpdate time to run
+  // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
 
   const userRecordEnabled = await adminAuth.getUserByEmail(testUserEmail);
@@ -356,14 +337,11 @@ test('User can be toggled between enabled and disabled', async () => {
 
 test('User can be toggled between isAdmin and not isAdmin', async () => {
   // Create a new user to avoid race conditions
-  await copyUser('user@soylentgreen.com', testUserEmail)
+  await copyUser('user@soylentgreen.com', testUserEmail);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      isAdmin: true,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    isAdmin: true,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
@@ -377,12 +355,9 @@ test('User can be toggled between isAdmin and not isAdmin', async () => {
   let idTokenResult = await clientAuth.currentUser.getIdTokenResult(true);
   expect(idTokenResult.claims.isAdmin).toEqual(true);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      isAdmin: false,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    isAdmin: false,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -1,4 +1,14 @@
-import { adminDb, clientAuth, adminAuth, createUser, delay, DELAY, soylentGreenID, clientDb } from './config';
+import {
+  adminDb,
+  clientAuth,
+  adminAuth,
+  createUser,
+  delay,
+  DELAY,
+  soylentGreenID,
+  clientDb,
+  getVerificationCode,
+} from './config';
 
 jest.setTimeout(120000);
 


### PR DESCRIPTION
The test to look at is called `'An attacker cannot create an account and then quickly create their own record in /users table before onCreate has time to run and delete them'`, the rest of the changes are formatting differences (argh!).

I thought up a potential attack where a user creates an account (in Firebase auth) through the client library, then quickly signs in and creates their own user document before our `onCreate` hook has time to run and delete their account. As it turns out, our `isAdmin()` rule protects against this, but I added a test to assure this is enforced.