### PR TITLE
Add email to sign in link url

### DIFF
--- a/cloud-functions/functions/src/index.ts
+++ b/cloud-functions/functions/src/index.ts
@@ -157,16 +157,19 @@ function isAdminGuard(context: functions.https.CallableContext): Promise<void> {
   });
 }
 
+function generateSignInWithEmailLink(email: string): Promise<string> {
+  return auth.generateSignInWithEmailLink(email, {
+    url: functions.config().client.url + `?email=${email}`,
+    // This must be true.
+    handleCodeInApp: true,
+  });
+}
+
 const EMAILSTYLE = `style="font-family: Montserrat, Arial, Helvetica, sans-serif;font-size:18px;color: #585858;"`;
 
 // Send email to new users instructing them to change their password
 function sendNewUserEmail(email: string, password: string, firstName: string, lastName: string) {
-  auth
-    .generateSignInWithEmailLink(email, {
-      url: functions.config().client.url,
-      // This must be true.
-      handleCodeInApp: true,
-    })
+  generateSignInWithEmailLink(email)
     .then((link) => {
       const msg = {
         to: email,
@@ -199,12 +202,7 @@ function sendNewUserEmail(email: string, password: string, firstName: string, la
 }
 
 function sendPasswordRecoveryEmail(email: string) {
-  auth
-    .generateSignInWithEmailLink(email, {
-      url: functions.config().client.url,
-      // This must be true.
-      handleCodeInApp: true,
-    })
+  generateSignInWithEmailLink(email)
     .then((link) => {
       const msg = {
         to: email,

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -58,9 +58,9 @@ const SignInFormBase = observer(
       // Based on https://firebase.google.com/docs/auth/web/email-link-auth
       if (this.props.store.isSignInWithEmailLink(window.location.href)) {
         Logging.log('signInWithEmailLink detected')
+        var email = new URL(location.href).searchParams.get('email')
         // Get the email if available. This should be available if the user completes
         // the flow on the same device where they started it.
-        var email = window.localStorage.getItem('emailForSignIn')
         if (!email) {
           // User opened the link on a different device. To prevent session fixation
           // attacks, ask the user to provide the associated email again. For example:
@@ -69,18 +69,9 @@ const SignInFormBase = observer(
         await this.props.store
           .signInWithEmailLink(email, window.location.href)
           .then(() => {
-            // Clear email from storage.
-            window.localStorage.removeItem('emailForSignIn')
-            // You can access the new user via result.user
-            // Additional user info profile not available via:
-            // result.additionalUserInfo.profile == null
-            // You can check if the user is new or existing:
-            // result.additionalUserInfo.isNewUser
             Logging.log('Logged in via signInWithEmailLink')
           })
           .catch((err) => {
-            // Some error occurred, you can inspect the code: error.code
-            // Common errors could be invalid email and invalid or expired OTPs.
             Logging.error(err)
           })
       }

--- a/frontend/client/src/store/index.js
+++ b/frontend/client/src/store/index.js
@@ -183,9 +183,6 @@ const createStore = (WrappedComponent) => {
     async sendPasswordRecoveryEmail(email) {
       try {
         await initiatePasswordRecoveryCallable({ email: email })
-        // Save the email locally so you don't need to ask the user for it again if they open the link on the same device.
-        // See https://firebase.google.com/docs/auth/web/email-link-auth#send_an_authentication_link_to_the_users_email_address
-        window.localStorage.setItem('emailForSignIn', email)
         return true
       } catch (err) {
         Logging.error(err)


### PR DESCRIPTION
Both password reseters and new users can now click the link in their email and be immediately signed in, and asked to change their passwords:

<img width="1440" alt="Screen Shot 2020-07-06 at 11 53 02 AM" src="https://user-images.githubusercontent.com/13578537/86613156-0b936580-bf66-11ea-90c7-308749cea4a9.png">

closes https://github.com/covidwatchorg/permission-portal/issues/304
