### PR TITLE
Auth protect get verification code

### DIFF
--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -1,4 +1,13 @@
-import { adminDb, clientAuth, adminAuth, createUser, delay, DELAY, soylentGreenID } from './config';
+import {
+  adminDb,
+  clientAuth,
+  adminAuth,
+  createUser,
+  getVerificationCode,
+  delay,
+  DELAY,
+  soylentGreenID,
+} from './config';
 
 jest.setTimeout(120000);
 
@@ -23,25 +32,22 @@ const testUserEmail =
  */
 async function copyUser(oldEmail: string, newEmail: string) {
   // Copy user data
-  const userData = (await adminDb.collection('users').doc(oldEmail).get()).data()!
-  await adminDb.collection('users').doc(newEmail).set(userData)
+  const userData = (await adminDb.collection('users').doc(oldEmail).get()).data()!;
+  await adminDb.collection('users').doc(newEmail).set(userData);
 
   // Create auth record
   const userRecord = await adminAuth.createUser({
     email: newEmail,
     password: newEmail,
-  })
-  testUid = userRecord.uid
+  });
+  testUid = userRecord.uid;
 }
 
 afterEach(async () => {
   try {
     await adminAuth.deleteUser(testUid);
     try {
-      await adminDb
-        .collection('users')
-        .doc(testUserEmail)
-        .delete();
+      await adminDb.collection('users').doc(testUserEmail).delete();
       await clientAuth.signOut().catch((err) => {
         console.error(err);
       });
@@ -68,8 +74,7 @@ test('createUser cannot be called without being authenticated', async () => {
 
 test('createUser cannot be called by non-admin', async () => {
   try {
-    await clientAuth
-      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com');
+    await clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com');
     try {
       await createUser({});
       fail("This shouldn't happen!");
@@ -84,8 +89,7 @@ test('createUser cannot be called by non-admin', async () => {
 });
 
 test('Email address can only be used once', async () => {
-  await clientAuth
-    .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
+  await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
   try {
     await createUser({
       email: 'user@soylentgreen.com',
@@ -106,13 +110,15 @@ test('Email address can only be used once', async () => {
 test('createUser works for admins', async () => {
   await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
 
-  const userRecord = (await createUser({
-    email: testUserEmail,
-    password: testUserEmail,
-    firstName: 'test',
-    lastName: 'user',
-    isAdmin: false,
-  })).data;
+  const userRecord = (
+    await createUser({
+      email: testUserEmail,
+      password: testUserEmail,
+      firstName: 'test',
+      lastName: 'user',
+      isAdmin: false,
+    })
+  ).data;
   testUid = userRecord.uid;
 
   // Check that the endpoint responded with the proper user
@@ -120,10 +126,7 @@ test('createUser works for admins', async () => {
 
   // Check that corresponding document in userImages was created
   console.log(`testUserEmail = ${testUserEmail}`);
-  const docSnapshot = await adminDb
-    .collection('userImages')
-    .doc(testUserEmail)
-    .get();
+  const docSnapshot = await adminDb.collection('userImages').doc(testUserEmail).get();
   expect(docSnapshot.exists).toEqual(true);
 
   // delay for 10 sec to allow functions.auth.user().onCreate to trigger and propagate
@@ -143,21 +146,23 @@ test('createUser works for admins', async () => {
   // Check that custom claims are being added properly
   expect(idTokenResult.claims.isAdmin).toEqual(false);
   expect(idTokenResult.claims.organizationID).toEqual(soylentGreenID);
-})
+});
 
 test('createUser works for emails with uppercase letters', async () => {
   await clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com');
-  
-  const userRecord = (await createUser({
-    email: 'UPPERCASE@email.com',
-    password: 'password',
-    firstName: 'test',
-    lastName: 'user',
-    isAdmin: false,
-  })).data;
+
+  const userRecord = (
+    await createUser({
+      email: 'UPPERCASE@email.com',
+      password: 'password',
+      firstName: 'test',
+      lastName: 'user',
+      isAdmin: false,
+    })
+  ).data;
 
   testUid = userRecord.uid;
-  
+
   // Check that the endpoint responded with the proper user
   expect(userRecord.email).toEqual('uppercase@email.com');
 
@@ -171,14 +176,11 @@ test('createUser works for emails with uppercase letters', async () => {
     throw new Error('clientAuth.currentUser returned null');
   }
   expect(currentUser.email).toEqual('uppercase@email.com');
-  
+
   await delay(DELAY);
-  const userDoc = await adminDb
-    .collection('users')
-    .doc('uppercase@email.com')
-    .get();
-  
-    expect(userDoc.exists).toBe(true);
+  const userDoc = await adminDb.collection('users').doc('uppercase@email.com').get();
+
+  expect(userDoc.exists).toBe(true);
   // delete uppercase user to keep test idempotent
   await adminDb.collection('users').doc('uppercase@email.com').delete();
 });
@@ -190,7 +192,7 @@ test('createUser fails if invalid request body', async () => {
       email: testUserEmail,
       password: testUserEmail,
       // Missing required fields
-    })
+    });
     fail('createUser returned a 200 despite improperly formatted request');
   } catch (err) {
     expect(err.code).toEqual('invalid-argument');
@@ -199,38 +201,31 @@ test('createUser fails if invalid request body', async () => {
 });
 
 test('Attempting to sign up a user through clientAuth.createUserWithEmailAndPassword and not through createUser endpoint results in the user being deleted', async () => {
-  const userCredential = await clientAuth
-    .createUserWithEmailAndPassword(testUserEmail, testUserEmail);
+  const userCredential = await clientAuth.createUserWithEmailAndPassword(testUserEmail, testUserEmail);
   expect(userCredential.user?.email).toEqual(testUserEmail);
   if (userCredential.user) {
     testUid = userCredential.user.uid;
   }
   await delay(DELAY * 2);
-  const user = await adminDb
-    .doc('users/' + testUserEmail)
-    .get();
+  const user = await adminDb.doc('users/' + testUserEmail).get();
   expect(user.exists).toEqual(false);
 });
 
 test("Manually added, improperly formatted user in users table can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      // This is missing fields
-    })
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    // This is missing fields
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    })
-  
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
+
   // delay to allow onCreate to trigger and realize users table document is faulty
-  await delay(DELAY * 2)
+  await delay(DELAY * 2);
 
   // check that user has been deleted from Firebase Auth
   try {
@@ -238,33 +233,26 @@ test("Manually added, improperly formatted user in users table can't be signed u
     fail("Improperly formatted user should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test("Manually added user in users table with non-existent organizationID can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      organizationID: "This id doesn't exist",
-      disabled: false,
-      firstName: 'test',
-      lastName: 'user',
-    });
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    organizationID: "This id doesn't exist",
+    disabled: false,
+    firstName: 'test',
+    lastName: 'user',
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    });
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
 
   // delay to allow onCreate to trigger and realize users table document is faulty
   await delay(DELAY * 2);
@@ -272,82 +260,62 @@ test("Manually added user in users table with non-existent organizationID can't 
   // check that user has been deleted from Firebase Auth
   try {
     await adminAuth.getUserByEmail(testUserEmail);
-    fail(
-      "User with non-existent organizationID should have been deleted from Auth but wasn't"
-    );
+    fail("User with non-existent organizationID should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test("Manually added user in users table with empty string organizationID can't be signed up", async () => {
   // set faulty document in users table
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .set({
-      isAdmin: false,
-      organizationID: '',
-      disabled: false,
-      firstName: 'test',
-      lastName: 'user',
-    });
+  await adminDb.collection('users').doc(testUserEmail).set({
+    isAdmin: false,
+    organizationID: '',
+    disabled: false,
+    firstName: 'test',
+    lastName: 'user',
+  });
 
   // try to create corresponding user in Firebase auth
-  await adminAuth
-    .createUser({
-      email: testUserEmail,
-      password: testUserEmail,
-    });
+  await adminAuth.createUser({
+    email: testUserEmail,
+    password: testUserEmail,
+  });
 
   // delay to allow onCreate to trigger and realize users table document is faulty
-  await delay(DELAY * 2)
+  await delay(DELAY * 2);
 
   // check that user has been deleted from Firebase Auth
   try {
     await adminAuth.getUserByEmail(testUserEmail);
-    fail(
-      "User with empty string organizationID should have been deleted from Auth but wasn't"
-    );
+    fail("User with empty string organizationID should have been deleted from Auth but wasn't");
   } catch (err1) {
     expect(true).toEqual(true);
-    const user = await adminDb
-      .collection('users')
-      .doc(testUserEmail)
-      .get();
+    const user = await adminDb.collection('users').doc(testUserEmail).get();
     expect(user.exists).toEqual(false);
   }
 });
 
 test('User can be toggled between enabled and disabled', async () => {
   // Create a new user to avoid race conditions
-  await copyUser('disabled@soylentgreen.com', testUserEmail)
+  await copyUser('disabled@soylentgreen.com', testUserEmail);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      disabled: false,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    disabled: false,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
 
   const userRecordDisabled = await adminAuth.getUserByEmail(testUserEmail);
   expect(userRecordDisabled.disabled).toBe(false);
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      disabled: true,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    disabled: true,
+  });
 
-    // Delay to allow userOnUpdate time to run
+  // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
 
   const userRecordEnabled = await adminAuth.getUserByEmail(testUserEmail);
@@ -356,14 +324,11 @@ test('User can be toggled between enabled and disabled', async () => {
 
 test('User can be toggled between isAdmin and not isAdmin', async () => {
   // Create a new user to avoid race conditions
-  await copyUser('user@soylentgreen.com', testUserEmail)
+  await copyUser('user@soylentgreen.com', testUserEmail);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      isAdmin: true,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    isAdmin: true,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
@@ -377,12 +342,9 @@ test('User can be toggled between isAdmin and not isAdmin', async () => {
   let idTokenResult = await clientAuth.currentUser.getIdTokenResult(true);
   expect(idTokenResult.claims.isAdmin).toEqual(true);
 
-  await adminDb
-    .collection('users')
-    .doc(testUserEmail)
-    .update({
-      isAdmin: false,
-    });
+  await adminDb.collection('users').doc(testUserEmail).update({
+    isAdmin: false,
+  });
 
   // Delay to allow userOnUpdate time to run
   await delay(DELAY * 5);
@@ -390,4 +352,14 @@ test('User can be toggled between isAdmin and not isAdmin', async () => {
   // Check that isAdmin claim has been updated properly
   idTokenResult = await clientAuth.currentUser.getIdTokenResult(true);
   expect(idTokenResult.claims.isAdmin).toEqual(false);
+});
+
+test('getVerificationCode cannot be called without being authenticated', async () => {
+  try {
+    await getVerificationCode({});
+    fail("This shouldn't happen!");
+  } catch (err) {
+    expect(err.code).toEqual('unauthenticated');
+    expect(err.message).toEqual('The function must be called while authenticated.');
+  }
 });

--- a/cloud-functions/functions/__tests__/config.ts
+++ b/cloud-functions/functions/__tests__/config.ts
@@ -44,6 +44,7 @@ export const adminDb = admin.firestore();
 export const clientAuth = firebase.auth();
 export const adminAuth = admin.auth();
 export const createUser = firebase.functions().httpsCallable('createUser');
+export const getVerificationCode = firebase.functions().httpsCallable('getVerificationCode');
 
 // Delay function to deal with Cloud Functions triggers needing time to propagate.
 export const delay = (t: number) => new Promise((resolve) => setTimeout(resolve, t));


### PR DESCRIPTION
All this talk about security testing in our meeting got me to thinking about whether we'd just exposed verification code generation to the entire world, which we had. This solves that.

Linter/formatter did a number on the `__tests__/auth.test.ts` file, but the substantive change is the test named `'getVerificationCode cannot be called without being authenticated'`.