### PR TITLE
Pass testType and testDate from the frontend to getVerificationCode

### DIFF
--- a/cloud-functions/functions/src/index.ts
+++ b/cloud-functions/functions/src/index.ts
@@ -445,7 +445,8 @@ export const initiatePasswordRecovery = functions.https.onCall((body) => {
   });
 });
 
-export const getVerificationCode = functions.https.onCall(async (_, context) => {
+// issueCodeRequest looks like {testType: "likely", testDate: "2020-07-02"} or {testType: "confirmed", testDate: "2020-07-02"}
+export const getVerificationCode = functions.https.onCall(async (issueCodeRequest, context) => {
   return new Promise((resolve, reject) => {
     authGuard(context)
       .then(async () => {
@@ -479,11 +480,9 @@ export const getVerificationCode = functions.https.onCall(async (_, context) => 
           });
 
           response = await instance.get(url + 'home/csrf');
-          response = await instance.post(
-            url + 'home/issue',
-            { testType: 'confirmed' },
-            { headers: { 'X-CSRF-TOKEN': response.data.csrftoken } }
-          );
+          response = await instance.post(url + 'home/issue', issueCodeRequest, {
+            headers: { 'X-CSRF-TOKEN': response.data.csrftoken },
+          });
           resolve(response.data.code);
         } catch (err) {
           reject(err);

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -24,7 +24,11 @@ const CodeValidationsBase = observer((props) => {
 
   const genNewCode = async () => {
     try {
-      let code = await props.store.getVerificationCode()
+      // TODO: testType and testDate should be set by fields in the interface; blocked awaiting v4 figma
+      let code = await props.store.getVerificationCode({
+        testType: 'confirmed',
+        testDate: new Date().toJSON().substring(0, 10),
+      })
       setCode(code.data.split('').join(' '))
     } catch (err) {
       setToastInfo({ success: false, msg: 'Could not generate new code, please try again' })

--- a/frontend/client/src/store/index.js
+++ b/frontend/client/src/store/index.js
@@ -209,9 +209,10 @@ const createStore = (WrappedComponent) => {
       }
     }
 
-    async getVerificationCode() {
+    // issueCodeRequest looks like {testType: "likely", testDate: "2020-07-02"} or {testType: "confirmed", testDate: "2020-07-02"}
+    async getVerificationCode(issueCodeRequest) {
       try {
-        return await getVerificationCodeCallable()
+        return await getVerificationCodeCallable(issueCodeRequest)
       } catch (err) {
         Logging.error(err)
         throw err


### PR DESCRIPTION
I've structured the frontend/backend so that it passes a hardcoded
```javascript
{
    testType: 'confirmed',
    testDate: new Date().toJSON().substring(0, 10),
}
```
from the frontend, preparing us for passing values taken from the interface (currently blocked by Figma v4).