### PR TITLE
Add Sentry error reporting

### DIFF
--- a/frontend/client/index.js
+++ b/frontend/client/index.js
@@ -1,6 +1,9 @@
 import ReactDOM from 'react-dom'
 import React from 'react'
 import App from './App'
+import * as Sentry from '@sentry/react'
 import './Styles/application.scss'
+
+Sentry.init({ dsn: 'https://13821d959c3a4f10944bb8ef579d034d@o410040.ingest.sentry.io/5283616' })
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1829,6 +1829,75 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sentry/browser": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.19.1.tgz",
+      "integrity": "sha512-Aon5Nc2n8sIXKg6Xbr4RM3/Xs7vFpXksL56z3yIuGrmpCM8ToQ25/tQv8h+anYi72x5bn1npzaXB/NwU1Qwfhg==",
+      "requires": {
+        "@sentry/core": "5.19.1",
+        "@sentry/types": "5.19.1",
+        "@sentry/utils": "5.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.19.1.tgz",
+      "integrity": "sha512-BGGxjeT95Og/hloBhQXAVcndVXPmIU6drtF3oKRT12cBpiG965xEDEUwiJVvyb5MAvojdVEZBK2LURUFY/d7Zw==",
+      "requires": {
+        "@sentry/hub": "5.19.1",
+        "@sentry/minimal": "5.19.1",
+        "@sentry/types": "5.19.1",
+        "@sentry/utils": "5.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.19.1.tgz",
+      "integrity": "sha512-XjfbNGWVeDsP38alm5Cm08YPIw5Hu6HbPkw7a3y1piViTrg4HdtsE+ZJqq0YcURo2RTpg6Ks6coCS/zJxIPygQ==",
+      "requires": {
+        "@sentry/types": "5.19.1",
+        "@sentry/utils": "5.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.19.1.tgz",
+      "integrity": "sha512-pgNfsaCroEsC8gv+NqmPTIkj4wyK6ZgYLV12IT4k2oJLkGyg45TSAKabyB7oEP5jsj8sRzm8tDomu8M4HpaCHg==",
+      "requires": {
+        "@sentry/hub": "5.19.1",
+        "@sentry/types": "5.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/react": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-5.19.1.tgz",
+      "integrity": "sha512-UbXjdqZs0v+QMTmuKfJG6QtCBRgsFVZy1H03tgB+VKgYF4MdOrH+TaPooVQgQHa40a6DbYA/2Fm/Ii4jMhjI5w==",
+      "requires": {
+        "@sentry/browser": "5.19.1",
+        "@sentry/types": "5.19.1",
+        "@sentry/utils": "5.19.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.19.1.tgz",
+      "integrity": "sha512-M5MhTLnjqYFwxMwcFPBpBgYQqI9hCvtVuj/A+NvcBHpe7VWOXdn/Sys+zD6C76DWGFYQdw3OWCsZimP24dL8mA=="
+    },
+    "@sentry/utils": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.19.1.tgz",
+      "integrity": "sha512-neUiNBnZSHjWTZWy2QV02EHTx1C2L3DBPzRXlh0ca5xrI7LMBLmhkHlhebn1E5ky3PW1teqZTgmh0jZoL99TEA==",
+      "requires": {
+        "@sentry/types": "5.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^3.2.10",
     "@material-ui/styles": "^4.9.14",
+    "@sentry/react": "^5.19.1",
     "babel-eslint": "^10.1.0",
     "babel-polyfill": "^6.26.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
[Sentry](https://sentry.io/) is an error reporting service Jeff suggested we use.  See a screen capture video I made [here](https://www.loom.com/share/989be1deb6434003a54ca10895e2a913) that describes how this works.

There are some more customized things we can do that may be desirable - such as some custom handling logic for what to display if the user errors out for some reason so it isn't just a blank white screen.  Maybe just trigger a refresh?  Or show a 'contact Covid Watch' message?  Not sure.  More info on this in the Sentry docs about ["error boundaries"](https://docs.sentry.io/platforms/javascript/react/#error-boundaries).

Suggestions welcome for what error boundaries to set up, if any, at this stage.  Otherwise, this is probably ok to merge now and we can improve the workflow later as we have a better sense of what is needed.  

Note: I don't believe the DSN code that Sentry uses (sort of like API credentials) is a security risk when exposed.  Sentry's docs don't mention this is important to protect (from what I've seen).

Our current Sentry plan (Hobbyist) allows for up to 5k errors/month at no charge.  That should be sufficient for now.