### PR TITLE
V4 code validations dates

### DIFF
--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -50,15 +50,14 @@ const CodeValidationsBase = observer((props) => {
   const handleDate = (e) => {
     e.target.classList.add('with-value')
     e.target.classList.remove('no-value')
-    const todayDate = new Date();
 
     // this logic here needs to be cleaned up.  specifically the moreThanFourteenDaysAgo and dateInFuture functions in time.js
     if (moreThanFourteenDaysAgo(e.target.value)) {
-      setToastInfo({ success: false, msg: "Chose a date of more than 14 days ago... defaulting to 14 days ago" })
+      setToastInfo({ success: false, msg: 'Date cannot be more than 14 days ago' })
       confirmedToast.current.show()
       setDate(getFourteenDaysAgo())
     } else if (dateInFuture(e.target.value)) {
-      setToastInfo({ success: false, msg: "Chose a date in the future... defaulting to today's date" })
+      setToastInfo({ success: false, msg: 'Date cannot be in the future' })
       confirmedToast.current.show()
       setDate(getDay())
     } else {

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -15,7 +15,7 @@ const codePlaceholder = '00000000'
 const CodeValidationsBase = observer((props) => {
   const [code, setCode] = useState(codePlaceholder)
   const [testType, setTestType] = useState('')
-  const [testDate, setDate] = useState('')
+  const [testDate, setTestDate] = useState('')
   const [buttonDisabled, setButtonDisabled] = useState(true)
   const [codeGenStamp, setCodeGenStamp] = useState('')
   const [toastInfo, setToastInfo] = useState({
@@ -51,20 +51,18 @@ const CodeValidationsBase = observer((props) => {
     e.target.classList.add('with-value')
     e.target.classList.remove('no-value')
 
-    // this logic here needs to be cleaned up.  specifically the moreThanFourteenDaysAgo and dateInFuture functions in time.js
+    // does not allow testDate in state to be set if date selected is more than 14 days ago or in the future
     if (moreThanFourteenDaysAgo(e.target.value)) {
       setToastInfo({ success: false, msg: 'Date cannot be more than 14 days ago' })
       confirmedToast.current.show()
-      setDate(getFourteenDaysAgo())
     } else if (dateInFuture(e.target.value)) {
       setToastInfo({ success: false, msg: 'Date cannot be in the future' })
       confirmedToast.current.show()
-      setDate(getDay())
     } else {
-      setDate(e.target.value)
-    }
-    if (testType !== '' && testDate === '') {
-      setButtonDisabled(false)
+      setTestDate(e.target.value)
+      if (testType !== '' && testDate === '') {
+        setButtonDisabled(false)
+      }
     }
   }
 
@@ -79,7 +77,7 @@ const CodeValidationsBase = observer((props) => {
     setButtonDisabled(true)
     setCode(codePlaceholder)
     setTestType('')
-    setDate('')
+    setTestDate('')
     setCodeGenStamp('')
   }
 
@@ -100,6 +98,10 @@ const CodeValidationsBase = observer((props) => {
       <PageTitle title="Diagnosis Verification Codes" />
       <h1>Diagnosis Verification Codes</h1>
       <h2>Submit this form when you are prepared to generate and immediately share the code with a patient.</h2>
+
+      <p>{code}</p>
+      <p>{testType}</p>
+      <p>{testDate}</p>
 
       <div className="row" id="test-type-form">
         <div className="col-1">

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -55,12 +55,14 @@ const CodeValidationsBase = observer((props) => {
     if (moreThanFourteenDaysAgo(e.target.value)) {
       setToastInfo({ success: false, msg: 'Date cannot be more than 14 days ago' })
       confirmedToast.current.show()
+      setButtonDisabled(true)
     } else if (dateInFuture(e.target.value)) {
       setToastInfo({ success: false, msg: 'Date cannot be in the future' })
       confirmedToast.current.show()
+      setButtonDisabled(true)
     } else {
       setTestDate(e.target.value)
-      if (testType !== '' && testDate === '') {
+      if (testType !== '' && testDate === '' || !dateInFuture(e.target.value) || !moreThanFourteenDaysAgo(e.target.value)) {
         setButtonDisabled(false)
       }
     }

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -18,6 +18,7 @@ const CodeValidationsBase = observer((props) => {
   const [testDate, setTestDate] = useState('')
   const [buttonDisabled, setButtonDisabled] = useState(true)
   const [codeGenStamp, setCodeGenStamp] = useState('')
+  const [expirationTime, setExpirationTime] = useState('')
   const [toastInfo, setToastInfo] = useState({
     success: false,
     msg: '',
@@ -62,7 +63,11 @@ const CodeValidationsBase = observer((props) => {
       setButtonDisabled(true)
     } else {
       setTestDate(e.target.value)
-      if ((testType !== '' && testDate === '') || (testType !== '' && !dateInFuture(e.target.value)) || (testType !== '' && !moreThanFourteenDaysAgo(e.target.value))) {
+      if (
+        (testType !== '' && testDate === '') ||
+        (testType !== '' && !dateInFuture(e.target.value) && testDate === '') ||
+        (testType !== '' && !moreThanFourteenDaysAgo(e.target.value) && testDate === '')
+      ) {
         setButtonDisabled(false)
       }
     }
@@ -89,6 +94,7 @@ const CodeValidationsBase = observer((props) => {
     document.getElementById('code-box').classList.toggle('no-value')
     document.getElementById('code-box').classList.toggle('code-generated')
     setCodeGenStamp(new Date().getMinutes())
+    setExpirationTime(getOneHourAhead())
   }
 
   return !props.store.data.user.isSignedIn ||
@@ -165,7 +171,7 @@ const CodeValidationsBase = observer((props) => {
             Generate Code
           </PendingOperationButton>
           <div id="code-box" className="no-value">
-              {code.slice(0, 3)}-{code.slice(3, 6)}-{code.slice(6)}
+            {code.slice(0, 3)}-{code.slice(3, 6)}-{code.slice(6)}
           </div>
 
           {code !== codePlaceholder && (
@@ -174,7 +180,7 @@ const CodeValidationsBase = observer((props) => {
                 <img src={Clock}></img>
                 <div>Share the code ASAP. &nbsp;</div>
                 <span>
-                  It will expire in {60 - Math.abs(codeGenStamp - new Date().getMinutes())} min at {getOneHourAhead()}
+                    It will expire in {60 - Math.abs(codeGenStamp - new Date().getMinutes())} min at {expirationTime}
                 </span>
               </div>
 

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -8,7 +8,7 @@ import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
 import Clock from '../../assets/clock.svg'
-import { getOneHourAhead, getDay, getFourteenDaysAgo } from '../util/time'
+import { getOneHourAhead, getDay, getFourteenDaysAgo, moreThanFourteenDaysAgo, dateInFuture } from '../util/time'
 
 const codePlaceholder = '00000000'
 
@@ -50,7 +50,20 @@ const CodeValidationsBase = observer((props) => {
   const handleDate = (e) => {
     e.target.classList.add('with-value')
     e.target.classList.remove('no-value')
-    setDate(e.target.value)
+    const todayDate = new Date();
+
+    // this logic here needs to be cleaned up.  specifically the moreThanFourteenDaysAgo and dateInFuture functions in time.js
+    if (moreThanFourteenDaysAgo(e.target.value)) {
+      setToastInfo({ success: false, msg: "Chose a date of more than 14 days ago... defaulting to 14 days ago" })
+      confirmedToast.current.show()
+      setDate(getFourteenDaysAgo())
+    } else if (dateInFuture(e.target.value)) {
+      setToastInfo({ success: false, msg: "Chose a date in the future... defaulting to today's date" })
+      confirmedToast.current.show()
+      setDate(getDay())
+    } else {
+      setDate(e.target.value)
+    }
     if (testType !== '' && testDate === '') {
       setButtonDisabled(false)
     }
@@ -154,7 +167,7 @@ const CodeValidationsBase = observer((props) => {
             Generate Code
           </PendingOperationButton>
           <div id="code-box" className="no-value">
-            {code.slice(0, 3)}-{code.slice(3, 6)}-{code.slice(6)}
+            {code.slice(0, 4)}-{code.slice(4)}
           </div>
 
           {code !== codePlaceholder && (

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -8,7 +8,7 @@ import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
 import Clock from '../../assets/clock.svg'
-import { getOneHourAhead, getDay, getFourteenDaysAgo, moreThanFourteenDaysAgo, dateInFuture } from '../util/time'
+import { getOneHourAhead, getFourteenDaysAgo, moreThanFourteenDaysAgo, dateInFuture, getUTCDate } from '../util/time'
 
 const codePlaceholder = '00000000'
 
@@ -62,7 +62,7 @@ const CodeValidationsBase = observer((props) => {
       setButtonDisabled(true)
     } else {
       setTestDate(e.target.value)
-      if (testType !== '' && testDate === '' || !dateInFuture(e.target.value) || !moreThanFourteenDaysAgo(e.target.value)) {
+      if ((testType !== '' && testDate === '') || (testType !== '' && !dateInFuture(e.target.value)) || (testType !== '' && !moreThanFourteenDaysAgo(e.target.value))) {
         setButtonDisabled(false)
       }
     }
@@ -143,7 +143,7 @@ const CodeValidationsBase = observer((props) => {
               className="no-value"
               type="date"
               min={getFourteenDaysAgo()}
-              max={getDay()}
+              max={getUTCDate()}
               onChange={handleDate}
             ></input>
           </form>

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -98,11 +98,6 @@ const CodeValidationsBase = observer((props) => {
       <PageTitle title="Diagnosis Verification Codes" />
       <h1>Diagnosis Verification Codes</h1>
       <h2>Submit this form when you are prepared to generate and immediately share the code with a patient.</h2>
-
-      <p>{code}</p>
-      <p>{testType}</p>
-      <p>{testDate}</p>
-
       <div className="row" id="test-type-form">
         <div className="col-1">
           <div className="sect-header">COVID-19 Diagnosis</div>
@@ -168,7 +163,7 @@ const CodeValidationsBase = observer((props) => {
             Generate Code
           </PendingOperationButton>
           <div id="code-box" className="no-value">
-            {code.slice(0, 4)}-{code.slice(4)}
+              {code.slice(0, 3)}-{code.slice(3, 6)}-{code.slice(6)}
           </div>
 
           {code !== codePlaceholder && (

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -56,7 +56,7 @@ export const getDay = (now = new Date()) => {
   if (day.length === 1) {
     day = '0' + day
   }
-  
+
   return year + '-' + month + '-' + day
 }
 

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -29,13 +29,19 @@ export const getFourteenDaysAgo = () => {
   var ourDate = new Date()
 
   //Change date picker minimum to be 14 days in the past.
-  var pastDate = ourDate.getDate() - 14
+  var pastDate = ourDate.getDate() - 13
   ourDate.setDate(pastDate)
 
   return getDay(ourDate)
 }
 
-// getDay generates a string formatted date
+// gets a current timestamp of the UTC time as a string:
+// ex: "2020-07-02"
+export const getUTCDate = () => {
+  return new Date().toJSON().substring(0, 10)
+}
+
+// getDay generates a string formatted date based on a date input
 // ex: "2020-07-16"
 export const getDay = (now = new Date()) => {
   const year = now.getFullYear().toString()
@@ -50,16 +56,18 @@ export const getDay = (now = new Date()) => {
   if (day.length === 1) {
     day = '0' + day
   }
-
+  
   return year + '-' + month + '-' + day
 }
 
 // is this date more than 14 days ago?
 export const moreThanFourteenDaysAgo = (strChosenDate) => {
   let chosenDate = new Date(strChosenDate)
-  let fourteenDaysAgo = new Date()
-  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
-  return chosenDate < fourteenDaysAgo
+  // adding + 1 to the chosenDate is necessary bc the way new Date() takes in a string seems to move it one date less on the returned Date
+  chosenDate.setDate(chosenDate.getDate() + 1)
+  let now = new Date()
+  now.setDate(now.getDate() - 14)
+  return chosenDate < now
 }
 
 // is this date in the future?

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -53,3 +53,24 @@ export const getDay = (now = new Date()) => {
 
   return year + '-' + month + '-' + day
 }
+
+export const moreThanFourteenDaysAgo = (strChosenDate) => {
+  // source for this approach
+  // https://stackoverflow.com/questions/54383799/check-if-date-string-is-greater-than-3-days
+
+  // I cannot figure out why date1 defaults to July 1 for me here but in my browser console when I do it, it generates: Thu Jul 16 2020 18:26:04 GMT-0700 (Pacific Daylight Time)
+  // maybe some weird setting on my computer that is reading a date wrong or something/?? idk I'm probably just making a dumb error somewhere
+
+  let date1 = new Date()
+  let date2 = new Date(strChosenDate)
+  var isLess = +date2 > date1.setDate(date1.getDate() - 14)
+  return isLess
+}
+
+// is this date in the future?
+export const dateInFuture = (strChosenDate) => {
+  let date1 = new Date()
+  let date2 = new Date(strChosenDate)
+  var isGreater = +date2 > date1.setDate(date1.getDate() + 1)
+  return isGreater
+}

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -54,23 +54,17 @@ export const getDay = (now = new Date()) => {
   return year + '-' + month + '-' + day
 }
 
+// is this date more than 14 days ago?
 export const moreThanFourteenDaysAgo = (strChosenDate) => {
-  // source for this approach
-  // https://stackoverflow.com/questions/54383799/check-if-date-string-is-greater-than-3-days
-
-  // I cannot figure out why date1 defaults to July 1 for me here but in my browser console when I do it, it generates: Thu Jul 16 2020 18:26:04 GMT-0700 (Pacific Daylight Time)
-  // maybe some weird setting on my computer that is reading a date wrong or something/?? idk I'm probably just making a dumb error somewhere
-
-  let date1 = new Date()
-  let date2 = new Date(strChosenDate)
-  var isLess = +date2 > date1.setDate(date1.getDate() - 14)
-  return isLess
+  let chosenDate = new Date(strChosenDate)
+  let fourteenDaysAgo = new Date()
+  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
+  return chosenDate < fourteenDaysAgo
 }
 
 // is this date in the future?
 export const dateInFuture = (strChosenDate) => {
-  let date1 = new Date()
-  let date2 = new Date(strChosenDate)
-  var isGreater = +date2 > date1.setDate(date1.getDate() + 1)
-  return isGreater
+  let chosenDate = new Date(strChosenDate)
+  let today = new Date()
+  return chosenDate > today
 }


### PR DESCRIPTION
Some minor workflow updates to the `CodeValidations.js` to maintain dates between today and 14 days ago.

Updates:

1) show Toast msg on choosing date out of bounds
2) do not allow code generation until a valid date is chosen
3) return to the code format 000-000-00 instead of 0000-0000

Preview:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16062590/87826185-6cfce380-c846-11ea-9bf7-296df3393c92.gif)
